### PR TITLE
feat: added settingsbutton for forcing external browser with payments sdk

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -29,7 +29,7 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'androidx.core:core-ktx:1.1.0'
 
-    implementation 'com.swedbankpay.mobilesdk:mobilesdk:1.0.0-beta09'
+    implementation 'com.swedbankpay.mobilesdk:mobilesdk:1.0.0-beta10'
 
     // appcompat 1.1.0 has a bug which causes crashes with WebView
     // https://issuetracker.google.com/issues/141132133

--- a/app/src/main/java/com/swedbankpay/exampleapp/cartsettings/CartAndSettingsAdapter.kt
+++ b/app/src/main/java/com/swedbankpay/exampleapp/cartsettings/CartAndSettingsAdapter.kt
@@ -195,6 +195,7 @@ class CartAndSettingsAdapter(
                         )
                         user_type_title.typeface = boldFont
                         user_country_title.typeface = boldFont
+                        browser_title.typeface = boldFont
 
                         val vm = adapter.viewModel
 
@@ -207,6 +208,15 @@ class CartAndSettingsAdapter(
                         initSettingWidget(adapter, currency_sek, R.string.currency_sek,
                             vm.currency, sek,
                             View.OnClickListener { vm.currency.value = sek }
+                        )
+
+                        initSettingWidget(adapter, browser_no, R.string.browser_no,
+                            vm.useBrowser, false,
+                            View.OnClickListener { vm.useBrowser.value = false }
+                        )
+                        initSettingWidget(adapter, browser_yes, R.string.browser_yes,
+                            vm.useBrowser, true,
+                            View.OnClickListener { vm.useBrowser.value = true }
                         )
 
                         initSettingWidget(adapter, user_anonymous, R.string.anonymous,

--- a/app/src/main/java/com/swedbankpay/exampleapp/products/ProductsViewModel.kt
+++ b/app/src/main/java/com/swedbankpay/exampleapp/products/ProductsViewModel.kt
@@ -64,6 +64,7 @@ class ProductsViewModel(app: Application) : AndroidViewModel(app) {
     }
 
     val optionsExpanded = MutableLiveData<Boolean>().apply { value = false }
+    val useBrowser = MutableLiveData(false)
 
     val isUserAnonymous = MutableLiveData<Boolean>().apply { value = true }
     val userCountry = MutableLiveData<UserCountry>().apply { value =
@@ -157,9 +158,11 @@ class ProductsViewModel(app: Application) : AndroidViewModel(app) {
                 PaymentFragment.ArgumentsBuilder()
                     .consumer(paymentFragmentConsumer.value)
                     .paymentOrder(it)
+                    .useBrowser(useBrowser.value ?: false)
                     .build()
             }
         }
+        addSource(useBrowser, observer)
         addSource(paymentFragmentConsumer, observer)
         addSource(paymentFragmentPaymentOrder, observer)
     }

--- a/app/src/main/res/layout/settings_cell.xml
+++ b/app/src/main/res/layout/settings_cell.xml
@@ -57,12 +57,41 @@
 
         <TextView
             style="@style/tiny_white_text"
-            android:id="@+id/user_type_title"
+            android:id="@+id/browser_title"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             app:layout_constraintStart_toEndOf="@id/open_settings"
             app:layout_constraintEnd_toStartOf="@id/close_settings"
             app:layout_constraintTop_toBottomOf="@id/currency_area"
+            android:layout_marginTop="16dp"
+            android:layout_marginStart="8dp"
+            android:layout_marginEnd="8dp"
+            android:gravity="center_horizontal"
+            android:text="@string/browser"/>
+        <LinearLayout
+            android:id="@+id/browser_area"
+            android:layout_width="0dp"
+            android:layout_height="48dp"
+            app:layout_constraintStart_toStartOf="@id/currency_title"
+            app:layout_constraintEnd_toEndOf="@id/currency_title"
+            app:layout_constraintTop_toBottomOf="@id/browser_title"
+            android:layout_marginTop="4dp"
+            android:orientation="horizontal"
+            android:baselineAligned="false">
+            <include android:id="@+id/browser_no"
+                layout="@layout/settings_option_label"/>
+            <include android:id="@+id/browser_yes"
+                layout="@layout/settings_option_label"/>
+        </LinearLayout>
+
+        <TextView
+            style="@style/tiny_white_text"
+            android:id="@+id/user_type_title"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            app:layout_constraintStart_toEndOf="@id/open_settings"
+            app:layout_constraintEnd_toStartOf="@id/close_settings"
+            app:layout_constraintTop_toBottomOf="@id/browser_area"
             android:layout_marginTop="16dp"
             android:layout_marginStart="8dp"
             android:layout_marginEnd="8dp"
@@ -115,7 +144,7 @@
             android:id="@+id/expanded_state_widgets"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            app:constraint_referenced_ids="close_settings,currency_title,currency_area,user_type_title,user_type_area,user_country_title,user_country_area"
+            app:constraint_referenced_ids="close_settings,currency_title,currency_area,browser_title,browser_area,user_type_title,user_type_area,user_country_title,user_country_area"
             />
     </androidx.constraintlayout.widget.ConstraintLayout>
 </FrameLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -24,6 +24,9 @@
     <string name="country">Country</string>
     <string name="norway">Norway</string>
     <string name="sweden">Sweden</string>
+    <string name="browser">Use Browser</string>
+    <string name="browser_yes">YES</string>
+    <string name="browser_no">NO</string>
 
     <string name="success_dialog_title">Payment successul!</string>
 


### PR DESCRIPTION
If the payment fails due to redirects, now we can try to force open them in an external browser. 
It's a toggle in the setting under the shopping cart. 